### PR TITLE
[BE][Feat] elasticsearch 설정(create, read, update)

### DIFF
--- a/backend/src/main/java/com/todayeat/backend/_common/response/success/SuccessType.java
+++ b/backend/src/main/java/com/todayeat/backend/_common/response/success/SuccessType.java
@@ -74,6 +74,7 @@ public enum SuccessType {
     GET_SALE_LIST_SUCCESS("판매 목록 조회에 성공하였습니다."),
     GET_SALE_DETAIL_SUCCESS("판매 상세 조회에 성공하였습니다."),
     UPDATE_SALE_SUCCESS("판매 수정에 성공하였습니다."),
+    UPDATE_SALE_IS_FINISHED_ALL_SUCCESS("모든 판매 종료에 성공하였습니다."),
     ;
 
     private final String msg;

--- a/backend/src/main/java/com/todayeat/backend/sale/controller/SaleController.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/controller/SaleController.java
@@ -51,5 +51,13 @@ public class SaleController implements SaleControllerDocs {
 
         return SuccessResponse.of(SuccessType.UPDATE_SALE_SUCCESS);
     }
+
+    @Override
+    public SuccessResponse<Void> updateIsFinishedAll(UpdateSaleIsFinishedAllRequest request) {
+
+        saleService.updateIsFinishedAll(request);
+
+        return SuccessResponse.of(SuccessType.UPDATE_SALE_IS_FINISHED_ALL_SUCCESS);
+    }
 }
 

--- a/backend/src/main/java/com/todayeat/backend/sale/controller/SaleControllerDocs.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/controller/SaleControllerDocs.java
@@ -2,7 +2,6 @@ package com.todayeat.backend.sale.controller;
 
 import com.todayeat.backend._common.response.error.ErrorResponse;
 import com.todayeat.backend._common.response.success.SuccessResponse;
-import com.todayeat.backend.menu.dto.response.GetMenuListResponse;
 import com.todayeat.backend.sale.dto.request.*;
 import com.todayeat.backend.sale.dto.response.GetSaleDetailConsumerResponse;
 import com.todayeat.backend.sale.dto.response.GetSaleListConsumerResponse;
@@ -118,4 +117,22 @@ public interface SaleControllerDocs {
                                        @RequestBody
                                        @Valid
                                        UpdateSaleRequest request);
+
+    @Operation(summary = "모든 판매 종료",
+            description = """
+                    `ROLE_SELLER` \n
+                    request body 넣어주세요.
+                    """)
+    @ApiResponse(responseCode = "200",
+            description = "성공")
+    @ApiResponse(responseCode = "404",
+            description = """ 
+                    판매자의 가게가 맞는지 확인, 가게 존재 여부 확인 \n
+                    """,
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @PutMapping(value = "/finish-all")
+    @PreAuthorize("hasRole('SELLER')")
+    SuccessResponse<Void> updateIsFinishedAll(@RequestBody
+                                              @Valid
+                                              UpdateSaleIsFinishedAllRequest request);
 }

--- a/backend/src/main/java/com/todayeat/backend/sale/dto/request/UpdateSaleIsFinishedAllRequest.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/dto/request/UpdateSaleIsFinishedAllRequest.java
@@ -1,0 +1,14 @@
+package com.todayeat.backend.sale.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "UpdateSaleIsFinishedAllRequest", description = "모든 판매 종료 요청")
+public class UpdateSaleIsFinishedAllRequest {
+
+    @NotNull(message = "storeId: 값이 null이 아니어야 합니다.")
+    @Schema(description = "가게 ID", example = "1")
+    private Long storeId;
+}

--- a/backend/src/main/java/com/todayeat/backend/sale/entity/Sale.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/entity/Sale.java
@@ -78,21 +78,21 @@ public class Sale extends BaseTime {
 
     public boolean update(String content, Boolean isFinished, Integer stock) {
 
-        this.content = content;
-
-        this.isFinished = isFinished;
-
         // todo 주문 접수 건수도 고려하기
 
         if (this.totalQuantity > stock) {
             return false;
         }
 
+        this.stock = stock;
+
+        this.content = content;
+
+        this.isFinished = isFinished;
+
         if(Objects.equals(this.totalQuantity, stock)) {
             this.isFinished = true;
         }
-
-        this.stock = stock;
 
         return true;
     }

--- a/backend/src/main/java/com/todayeat/backend/sale/repository/SaleRepository.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/repository/SaleRepository.java
@@ -3,6 +3,9 @@ package com.todayeat.backend.sale.repository;
 import com.todayeat.backend.sale.entity.Sale;
 import com.todayeat.backend.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +23,8 @@ public interface SaleRepository extends JpaRepository<Sale, Long> {
     List<Sale> findAllByStoreAndDeletedAtIsNull(Store store);
 
     List<Sale> findAllByStoreAndIsFinishedIsFalseAndDeletedAtIsNull(Store store);
+
+    @Modifying
+    @Query("UPDATE Sale s SET s.isFinished = true WHERE s.store = :store AND s.isFinished = false AND s.deletedAt IS NULL")
+    void updateAllSalesAsFinishedForStore(@Param("store") Store store);
 }

--- a/backend/src/main/java/com/todayeat/backend/sale/service/SaleService.java
+++ b/backend/src/main/java/com/todayeat/backend/sale/service/SaleService.java
@@ -63,6 +63,8 @@ public class SaleService {
         }
 
         saleRepository.saveAll(saleList);
+
+        store.updateIsOpened(true);
     }
 
     public GetSaleListConsumerResponse getListToConsumer(Long storeId) {
@@ -128,6 +130,19 @@ public class SaleService {
         if(!sale.update(request.getContent(), request.getIsFinished(), request.getStock())) {
             throw new BusinessException(ErrorType.SALE_STOCK_UPDATE_FAIL);
         }
+    }
+
+    @Transactional
+    public void updateIsFinishedAll(UpdateSaleIsFinishedAllRequest request) {
+
+        Seller seller = securityUtil.getSeller();
+
+        // 판매자의 가게가 맞는지 확인, 가게 존재 여부 확인
+        Store store = validateStoreAndSeller(seller, request.getStoreId());
+
+        saleRepository.updateAllSalesAsFinishedForStore(store);
+
+        store.updateIsOpened(false);
     }
 
     // 판매자의 가게가 맞는지 확인, 가게 존재 여부 확인

--- a/backend/src/main/java/com/todayeat/backend/store/entity/Store.java
+++ b/backend/src/main/java/com/todayeat/backend/store/entity/Store.java
@@ -78,8 +78,8 @@ public class Store extends BaseTime {
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
     private List<StoreCategory> storeCategoryList = new ArrayList<>();
 
-    public void updateIsOpened() {
-        this.isOpened = !this.isOpened;
+    public void updateIsOpened(Boolean isOpened) {
+        this.isOpened = isOpened;
     }
 
     public void updateFavoriteCnt(int value) {

--- a/backend/src/main/java/com/todayeat/backend/store/service/StoreServiceQueryDSLImpl.java
+++ b/backend/src/main/java/com/todayeat/backend/store/service/StoreServiceQueryDSLImpl.java
@@ -41,7 +41,7 @@ import static com.todayeat.backend._common.response.error.ErrorType.*;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class StoreServiceQueryDSLImpl implements StoreService{
+public class StoreServiceQueryDSLImpl implements StoreService {
 
     private final StoreCategoryRepository storeCategoryRepository;
     private final FavoriteRepository favoriteRepository;
@@ -100,17 +100,11 @@ public class StoreServiceQueryDSLImpl implements StoreService{
             throw new BusinessException(STORE_NOT_FOUND);
         }
 
-        store = storeRepository.findByIdAndDeletedAtIsNull(store.getId())
-                .orElseThrow(() -> new BusinessException(ErrorType.STORE_NOT_FOUND));
-
-        GetSellerStoreResponse getSellerStoreResponse = StoreMapper.INSTANCE.storeToGetSellerStoreResponse(store);
-
-        getSellerStoreResponse.setCategoryList(
+        return StoreMapper.INSTANCE.storeToGetSellerStoreResponse(
+                validateAndGetStore(storeId),
                 categoryRepository.findAll().stream()
                         .map(CategoryMapper.INSTANCE::categoryToCategoryInfo)
                         .collect(Collectors.toList()));
-
-        return getSellerStoreResponse;
     }
 
     @Override


### PR DESCRIPTION
In GitLab by @tddudwns1 on May 15, 2024, 12:12

## 🔎 작업 내용

### elasticsearch 초기 설정
- 의존성 추가
- 환경변수 추가
- config 파일 추가

---

### 가게 등록 mariaDB, elasticsearch 동시 저장 구현 
1. elasticsearch용 store document 생성
- store 데이터저장
- 검색에는 id, 위치, 이름, 영업 중 여부, 리뷰 수, 찜 수, 카테고리만 쓰임
- 나머지 검색이 필요 없는 데이터는 text 지정 해제, keyword만 지정
- 메뉴는 추후에 구현 예정
- 위치는 elasticsearch에서 geo_point type 선언
- 카테고리는 객체 목록이기 때문에 nested type 선언
2. ElasticsearchRepository extends한 interface 구현
- elasticsearch에 저장 용도
3. Elasticsearch용 service 생성
- 시간 비교를 위해 기존 queryDSL 사용 service도 유지
- service interface 만들고 impl로 구분
- 구분된 service 설정하기 위해 service config 파일 생성
4. StoreDocument mapping용 method 구현

기타
1. elasticsearch config package 위치 변경
- 기존 test에서 config로 이동(test 내부에 두면 내부 구현체만 config 적용 됨)

---

### 가게 단일 조회 elasticsearch 이용 구현
1. 기존 db 조회 로직 elasticsearch 조회 로직으로 수정
2. mapstruct에 document mapping 로직 추가
- mapping에 용이하도록 naming 수정

---

### 가게 수정 elasticsearch 적용 구현
- delete and create 방식으로 update 구현

<br/>

## 🚩 참고 사항

1. 이 다음에 메뉴 관련 로직 작성 예정
- 판매 등록 -> 영업 시작(판매 등록 여부 확인)
- 영업 종료(판매 테이블 제거)
- 판매 등록, 수정, 제거 시 elasticsearch에 반영

<br/>

## ✈️ MR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] UI 추가 및 변경

<br/>